### PR TITLE
setup.py for PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 out/
 *.png
 *.jpg
+build
+dist
+magick_tile.egg-info

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if shutil.which('convert') is None:
     sys.exit("Please install ImageMagick, and make sure it is in your system path.")
 
 setuptools.setup(
-    name = 'magick-tile',
+    name = 'magick_tile',
     version = version,
     url = 'https://github.com/cmu-lib/magick_tile/',
     author = 'Matthew Lincoln',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+import sys
+import shutil 
+import setuptools
+
+version = '0.0.1'
+
+with open("README.md") as f:
+    long_description = f.read()
+
+if shutil.which('convert') is None:
+    sys.exit("Please install ImageMagick, and make sure it is in your system path.")
+
+setuptools.setup(
+    name = 'magick-tile',
+    version = version,
+    url = 'https://github.com/cmu-lib/magick_tile/',
+    author = 'Matthew Lincoln',
+    author_email = 'mlincoln@andrew.cmu.edu',
+    license = 'MIT',
+    py_modules = ['magick_tile'],
+    description = 'Write iiif-image tiles using ImageMagick',
+    long_description = long_description,
+    long_description_content_type = "text/markdown",
+    install_requires=['tqdm'],
+    python_requires='>=3.*',
+    entry_points = {
+        'console_scripts': ['magick_tile=magick_tile:main']
+    },
+)


### PR DESCRIPTION
Here's a `setup.py` that should make it possible to `pip install magick_tile` once you've cut a release for PyPI. It will check to make sure ImageMagick is installed by searching for 'convert' on your path. You will want to update the `version` variable when you are creating a new release.

If you haven't uploaded a module to PyPI here are the steps:

1. create an account at https://pypi.org/ 
2. pip install twine
3. python setup.py sdist
4. twine upload dist/magick_tile-0.0.1.tar.gz