### PR TITLE
Spaces in sourcepath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 import shutil
 import setuptools
 
-version = "0.0.1"
+version = "0.0.2"
 
 with open("README.md") as f:
     long_description = f.read()


### PR DESCRIPTION
This commit adds a new method get_dimensions() that is a bit more
verbose, but also a bit more careful about finding the dimensions in the
output of inspect. The problem was that the splitting of the output on
spaces needed to change when the filename had one or more spaces in it.
Now a regular expression is used to find the two numbers separated by an
"x".

fixes #2