### PR TITLE
capture_output not supported on Python 3.6

### DIFF
--- a/magick_tile.py
+++ b/magick_tile.py
@@ -103,7 +103,8 @@ class Tiler:
             file_w = ceil(w / sf) if w < self.tile_size * sf else self.tile_size
             file_h = floor(h / sf) if h < self.tile_size * sf else self.tile_size
             target_dir = f"{output_dir}/{x},{y},{w},{h}/{file_w},/0"
-            os.makedirs(target_dir)
+            if not os.path.isdir(target_dir):
+                os.makedirs(target_dir)
             res = subprocess.call(
                 [
                     "convert",

--- a/magick_tile.py
+++ b/magick_tile.py
@@ -174,7 +174,7 @@ class Tiler:
         """
         Get the dimensions of the sourcepath as [x, y]
         """
-        r = subprocess.run(['identify', '-ping', self.sourcepath], capture_output=True)
+        r = subprocess.run(['identify', '-ping', self.sourcepath], stdout=subprocess.PIPE)
         s = r.stdout.decode('utf-8')
         dims = re.search('(\d+)x(\d+)', s).groups()
         return [int(d) for d in dims]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 import shutil
 import setuptools
 
-version = "0.0.2"
+version = "0.0.3"
 
 with open("README.md") as f:
     long_description = f.read()


### PR DESCRIPTION
I noticed that capture_output isn't an option for python 3.6 so I moved it back to use stdout=subprocess.PIPE instead. This way it is consistently used through the module as well.